### PR TITLE
Support configuring the marker function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install i18n-extract
 
 ## Usage
 
-### extractFromContent(content)
+### extractFromContent(content, [options])
 
 Parse the `content` to extract the argument of calls of i18n(`message`). 
 
@@ -27,7 +27,7 @@ var messages = i18nExtract.extractFromContent("
 // messages contains ['Follow', 'Follow me']
 ```
 
-### extractFromFiles(files)
+### extractFromFiles(files, [options])
 
 Parse the `files` to extract the argument of calls of i18n(`message`).
 
@@ -38,6 +38,10 @@ Parse the `files` to extract the argument of calls of i18n(`message`).
 var i18nExtract = require('i18n-extract');
 var messages = i18nExtract.extractFromFile(['*.jsx', '*.js']);
 ```
+
+### Options
+
+`marker`: The name of the internationalized string marker function. Defaults to `i18n`.
 
 ### mergeMessagesWithPO(messages, poInput, poOutput)
 

--- a/index.js
+++ b/index.js
@@ -29,8 +29,9 @@ function match(actual, expected) {
   }
 }
 
-function extractFromContent(content) {
+function extractFromContent(content, options) {
   var messages = [];
+  options = options || {};
 
   function getMessage(node) {
     if (node.type === 'Literal') {
@@ -50,7 +51,7 @@ function extractFromContent(content) {
     type: 'CallExpression',
     callee: {
       type: 'Identifier',
-      name: 'i18n',
+      name: options.marker || 'i18n',
     },
   };
 
@@ -74,7 +75,7 @@ function extractFromContent(content) {
   return uniq(messages);
 }
 
-function extractFromFiles(filenames) {
+function extractFromFiles(filenames, options) {
   var messages = [];
 
   // filenames should be an array
@@ -92,7 +93,7 @@ function extractFromFiles(filenames) {
 
   filenamesToScan.forEach(function(filename) {
     var content = fs.readFileSync(filename);
-    messages = messages.concat(extractFromContent(content));
+    messages = messages.concat(extractFromContent(content, options));
   });
 
   return uniq(messages);


### PR DESCRIPTION
The default in webpack is `__`, so that's what I'd like to use. My script looks like this:

```javascript
#!/usr/bin/env node

var fs = require('fs');
var extract = require('i18n-extract').extractFromFiles;

var messages = extract([
  'src/client/**/*.jsx',
  'src/client/**/*.js'
], {
  marker: '__',
});

messages.sort();

var obj = {};
messages.forEach(function(msg) {
  obj[msg] = msg;
});

fs.writeFileSync('i18n/en.json', JSON.stringify(obj, null, 4), 'utf8');
```