### PR TITLE
Enable dynamicImport plugin in babylon

### DIFF
--- a/src/extractFromCode.js
+++ b/src/extractFromCode.js
@@ -52,6 +52,7 @@ export default function extractFromCode(code, options = {}) {
       'asyncGenerators',
       'functionBind',
       'functionSent',
+      'dynamicImport',
     ],
   });
 

--- a/src/extractFromCode.spec.js
+++ b/src/extractFromCode.spec.js
@@ -93,6 +93,14 @@ describe('#extractFromCode()', () => {
         '*',
       ], keys, 'Should return one key.');
     });
+
+    it('should return the right key with dynamic import in code', () => {
+      const keys = extractFromCode(getCode('dynamicImport.js'));
+
+      assert.deepEqual([
+        'key',
+      ], keys, 'Should return only one key.');
+    });
   });
 
   describe('dynamic keys', () => {

--- a/src/extractFromCodeFixtures/dynamicImport.js
+++ b/src/extractFromCodeFixtures/dynamicImport.js
@@ -1,0 +1,7 @@
+/* eslint-disable */
+
+import i18n from 'i18n';
+
+import('other/file');
+
+i18n(`key`);


### PR DESCRIPTION
Currently i18n-extract crashes on files which use dynamic import
statements. This can be fixed by activating the corresponding babylon
plugin.