### PR TITLE
Add support for i18n-extract comments with spaces

### DIFF
--- a/src/extractFromCode.js
+++ b/src/extractFromCode.js
@@ -26,7 +26,7 @@ function getKey(node) {
   return null;
 }
 
-const commentRegExp = /i18n-extract (\S+)/;
+const commentRegExp = /i18n-extract (.+)/;
 
 export default function extractFromCode(code, options = {}) {
   const {
@@ -61,9 +61,8 @@ export default function extractFromCode(code, options = {}) {
   // Look for keys in the comments.
   ast.comments.forEach((comment) => {
     const match = commentRegExp.exec(comment.value);
-
     if (match) {
-      keys.push(match[1]);
+      keys.push(match[1].trim());
     }
   });
 

--- a/src/extractFromCode.spec.js
+++ b/src/extractFromCode.spec.js
@@ -131,6 +131,8 @@ describe('#extractFromCode()', () => {
       assert.deepEqual([
         'foo.bar1',
         'foo.bar2',
+        'foo spaced1',
+        'foo spaced2',
       ], keys, 'Should return the good keys.');
     });
   });

--- a/src/extractFromCodeFixtures/comment.js
+++ b/src/extractFromCodeFixtures/comment.js
@@ -2,3 +2,5 @@
 
 /* i18n-extract foo.bar1 */
 // i18n-extract foo.bar2
+/* i18n-extract foo spaced1 */
+// i18n-extract foo spaced2


### PR DESCRIPTION
Grab everything in the comment's value after "i18n-extract " and then trim it to get the final key.