### PR TITLE
Add the ability to ignore a given line of code with a comment

### DIFF
--- a/src/extractFromCode.spec.js
+++ b/src/extractFromCode.spec.js
@@ -124,7 +124,7 @@ describe('#extractFromCode()', () => {
     });
   });
 
-  describe('comment', () => {
+  describe('include comment', () => {
     it('should return the keys when added as a comment', () => {
       const keys = extractFromCode(getCode('comment.js'));
 
@@ -133,6 +133,17 @@ describe('#extractFromCode()', () => {
         'foo.bar2',
         'foo spaced1',
         'foo spaced2',
+      ], keys, 'Should return the good keys.');
+    });
+  });
+
+  describe('disable line comment', () => {
+    it('should ignore the keys from a line disabled from comment', () => {
+      const keys = extractFromCode(getCode('disable-comment.js'));
+
+      assert.deepEqual([
+        'foo.bar1',
+        'foo.bar3',
       ], keys, 'Should return the good keys.');
     });
   });

--- a/src/extractFromCodeFixtures/disable-comment.js
+++ b/src/extractFromCodeFixtures/disable-comment.js
@@ -1,0 +1,11 @@
+/* eslint-disable */
+import i18n from 'i18n';
+
+i18n('foo.bar1');
+i18n('foo.bar2');  /* i18n-extract-disable-line */
+i18n('foo.bar4');  /*
+                    * i18n-extract-disable-line
+                    */
+i18n('foo.bar5');  // i18n-extract-disable-line
+/* i18n-extract-disable-line */  i18n('foo.bar6');
+i18n('foo.bar3');


### PR DESCRIPTION
Just as `eslint` has a comment directive to disable a given line, this
commit adds a `i18n-extract-disable-line` comment to disable extraction
froma given line of code.

This fixes #32.