### PR TITLE
Add extractFromFiles option keyLoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ const keys = extractFromFiles([
 ### Options
 
 - `marker`: The name of the internationalized string marker function. Defaults to `i18n`.
+- `keyLoc`: An integer indicating the position of the key in the arguments. Defaults to `0`. Negative numbers, e.g., `-1`, indicate a position relative to the end of the arguemtn list.
 
 ### findMissing(locale, keysUsed)
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const keys = extractFromFiles([
 ### Options
 
 - `marker`: The name of the internationalized string marker function. Defaults to `i18n`.
-- `keyLoc`: An integer indicating the position of the key in the arguments. Defaults to `0`. Negative numbers, e.g., `-1`, indicate a position relative to the end of the arguemtn list.
+- `keyLoc`: An integer indicating the position of the key in the arguments. Defaults to `0`. Negative numbers, e.g., `-1`, indicate a position relative to the end of the argument list.
 
 ### findMissing(locale, keysUsed)
 

--- a/src/extractFromCode.js
+++ b/src/extractFromCode.js
@@ -31,6 +31,7 @@ const commentIgnoreRegExp = /i18n-extract-disable-line/;
 export default function extractFromCode(code, options = {}) {
   const {
     marker = 'i18n',
+    keyLoc = 0,
   } = options;
 
   const ast = parse(code, {
@@ -97,7 +98,8 @@ export default function extractFromCode(code, options = {}) {
 
       if ((type === 'Identifier' && name === marker) ||
         path.get('callee').matchesPattern(marker)) {
-        const key = getKey(node.arguments[0]);
+        const key = getKey(keyLoc < 0 ? node.arguments[node.arguments.length + keyLoc] :
+              node.arguments[keyLoc]);
 
         if (key) {
           keys.push({

--- a/src/extractFromCode.spec.js
+++ b/src/extractFromCode.spec.js
@@ -165,7 +165,30 @@ describe('#extractFromCode()', () => {
           key: 'this_is_a_custom_marker',
           loc: {
             end: {
-              column: 29,
+              column: 56,
+              line: 5,
+            },
+            start: {
+              column: 0,
+              line: 5,
+            },
+          },
+        },
+      ], keys, 'Should take into account the marker option.');
+    });
+
+    it('should return the right keys with a custom keyLoc', () => {
+      const keys = extractFromCode(getCode('marker.js'), {
+        marker: '__',
+        keyLoc: -1,
+      });
+
+      assert.deepEqual([
+        {
+          key: 'this_is_a_custom_keyLoc',
+          loc: {
+            end: {
+              column: 56,
               line: 5,
             },
             start: {

--- a/src/extractFromCodeFixtures/marker.js
+++ b/src/extractFromCodeFixtures/marker.js
@@ -2,4 +2,4 @@
 
 import __ from 'i18n';
 
-__('this_is_a_custom_marker');
+__('this_is_a_custom_marker', 'this_is_a_custom_keyLoc');


### PR DESCRIPTION
  - keyLoc: An integer to indicate the position of key in the arguments.
  Defaults to `0`, i.e., using the first argument as the key.
  - This is to better support i18n-webpack-plugin, which can take one or
  two arguments. When two arguments are provided, the sedond one is used
  as the key. To correctly extract key, we can set keyLoc to `-1` to
  use the last argument as key.