### PR TITLE
Add support for ternary operator and logical expressions

### DIFF
--- a/src/extractFromCode.js
+++ b/src/extractFromCode.js
@@ -17,6 +17,16 @@ function getKeys(node) {
     return [node.quasis.map(quasi => quasi.value.cooked).join('*')];
   } else if (node.type === 'ConditionalExpression') {
     return [...getKeys(node.consequent), ...getKeys(node.alternate)];
+  } else if (node.type === 'LogicalExpression') {
+    switch (node.operator) {
+      case '&&':
+        return [...getKeys(node.right)];
+      case '||':
+        return [...getKeys(node.left), ...getKeys(node.right)];
+      default:
+        console.warn(`unsupported logicalExpression's operator: ${node.operator}`);
+        return [null];
+    }
   } else if (noInformationTypes.includes(node.type)) {
     return ['*']; // We can't extract anything.
   }

--- a/src/extractFromCode.js
+++ b/src/extractFromCode.js
@@ -95,9 +95,7 @@ export default function extractFromCode(code, options = {}) {
         return;
       }
 
-      const {
-        callee: { name, type },
-      } = node;
+      const { callee: { name, type } } = node;
 
       if ((type === 'Identifier' && name === marker) || path.get('callee').matchesPattern(marker)) {
         const foundKeys = getKeys(

--- a/src/extractFromCode.spec.js
+++ b/src/extractFromCode.spec.js
@@ -658,11 +658,11 @@ describe('#extractFromCode()', () => {
             loc: {
               end: {
                 column: 23,
-                line: 7,
+                line: 8,
               },
               start: {
                 column: 0,
-                line: 7,
+                line: 8,
               },
             },
           },
@@ -671,11 +671,50 @@ describe('#extractFromCode()', () => {
             loc: {
               end: {
                 column: 23,
-                line: 7,
+                line: 8,
               },
               start: {
                 column: 0,
-                line: 7,
+                line: 8,
+              },
+            },
+          },
+          {
+            key: '*',
+            loc: {
+              end: {
+                column: 50,
+                line: 11,
+              },
+              start: {
+                column: 0,
+                line: 11,
+              },
+            },
+          },
+          {
+            key: 'baz',
+            loc: {
+              end: {
+                column: 50,
+                line: 11,
+              },
+              start: {
+                column: 0,
+                line: 11,
+              },
+            },
+          },
+          {
+            key: 'bar',
+            loc: {
+              end: {
+                column: 50,
+                line: 11,
+              },
+              start: {
+                column: 0,
+                line: 11,
               },
             },
           },

--- a/src/extractFromCode.spec.js
+++ b/src/extractFromCode.spec.js
@@ -724,4 +724,82 @@ describe('#extractFromCode()', () => {
       );
     });
   });
+
+  describe('logical expression', () => {
+    it('should parse logical expressions', () => {
+      const keys = extractFromCode(getCode('logicalExpression.js'));
+
+      assert.deepEqual(
+        [
+          {
+            key: 'bar',
+            loc: {
+              end: {
+                column: 18,
+                line: 8,
+              },
+              start: {
+                column: 0,
+                line: 8,
+              },
+            },
+          },
+          {
+            key: '*',
+            loc: {
+              end: {
+                column: 18,
+                line: 11,
+              },
+              start: {
+                column: 0,
+                line: 11,
+              },
+            },
+          },
+          {
+            key: 'baz',
+            loc: {
+              end: {
+                column: 18,
+                line: 11,
+              },
+              start: {
+                column: 0,
+                line: 11,
+              },
+            },
+          },
+          {
+            key: 'bar',
+            loc: {
+              end: {
+                column: 27,
+                line: 14,
+              },
+              start: {
+                column: 0,
+                line: 14,
+              },
+            },
+          },
+          {
+            key: 'baz',
+            loc: {
+              end: {
+                column: 27,
+                line: 14,
+              },
+              start: {
+                column: 0,
+                line: 14,
+              },
+            },
+          },
+        ],
+        keys,
+        'Should return the good keys.',
+      );
+    });
+  });
 });

--- a/src/extractFromCode.spec.js
+++ b/src/extractFromCode.spec.js
@@ -646,4 +646,43 @@ describe('#extractFromCode()', () => {
       );
     });
   });
+
+  describe('ternary operator', () => {
+    it('should parse ternary operator', () => {
+      const keys = extractFromCode(getCode('ternaryOperator.js'));
+
+      assert.deepEqual(
+        [
+          {
+            key: '*',
+            loc: {
+              end: {
+                column: 23,
+                line: 7,
+              },
+              start: {
+                column: 0,
+                line: 7,
+              },
+            },
+          },
+          {
+            key: 'bar',
+            loc: {
+              end: {
+                column: 23,
+                line: 7,
+              },
+              start: {
+                column: 0,
+                line: 7,
+              },
+            },
+          },
+        ],
+        keys,
+        'Should return the good keys.',
+      );
+    });
+  });
 });

--- a/src/extractFromCodeFixtures/logicalExpression.js
+++ b/src/extractFromCodeFixtures/logicalExpression.js
@@ -1,0 +1,14 @@
+/* eslint-disable */
+
+import i18n from 'i18n';
+
+const foo = true;
+
+// &&
+i18n(foo && 'bar');
+
+// ||
+i18n(foo || 'baz');
+
+// mixed
+i18n('bar' || foo && 'baz');

--- a/src/extractFromCodeFixtures/ternaryOperator.js
+++ b/src/extractFromCodeFixtures/ternaryOperator.js
@@ -1,0 +1,7 @@
+/* eslint-disable */
+
+import i18n from 'i18n';
+
+const foo = 'bar';
+
+i18n(foo ? foo : 'bar');

--- a/src/extractFromCodeFixtures/ternaryOperator.js
+++ b/src/extractFromCodeFixtures/ternaryOperator.js
@@ -4,4 +4,8 @@ import i18n from 'i18n';
 
 const foo = 'bar';
 
+// simple
 i18n(foo ? foo : 'bar');
+
+// nested
+i18n(foo ? (foo.length > 1 ? foo : 'baz') : 'bar');


### PR DESCRIPTION
Hi,

This fix makes the ``getKey`` to be replaced with ``getKeys`` that is now able to return multiple keys at once. That way we can add support for logical expressions and ternary operators that required the ability to return multiple keys.

Fix #39