### PR TITLE
Replace useTypeScript by parser in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const keys = extractFromFiles([
 
 - `marker`: The name of the internationalized string marker function. Defaults to `i18n`.
 - `keyLoc`: An integer indicating the position of the key in the arguments. Defaults to `0`. Negative numbers, e.g., `-1`, indicate a position relative to the end of the argument list.
-- `parser`: Enum indicate the parser use, can be `typescript` or `flow`. Defaults to `flow`.`
+- `parser`: Enum indicate the parser to use, can be `typescript` or `flow`. Defaults to `flow`.`
 
 ### findMissing(locale, keysUsed)
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const keys = extractFromFiles([
 
 - `marker`: The name of the internationalized string marker function. Defaults to `i18n`.
 - `keyLoc`: An integer indicating the position of the key in the arguments. Defaults to `0`. Negative numbers, e.g., `-1`, indicate a position relative to the end of the argument list.
-- `parser`: Enum indicate the parser to use, can be `typescript` or `flow`. Defaults to `flow`.`
+- `parser`: Enum indicate the parser to use, can be `typescript` or `flow`. Defaults to `flow`.
 
 ### findMissing(locale, keysUsed)
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const keys = extractFromFiles([
 
 - `marker`: The name of the internationalized string marker function. Defaults to `i18n`.
 - `keyLoc`: An integer indicating the position of the key in the arguments. Defaults to `0`. Negative numbers, e.g., `-1`, indicate a position relative to the end of the argument list.
-- `useTypeScript`: Defaults to `false`.
+- `parser`: Enum indicate the parser use, can be `typescript` or `flow`. Defaults to `flow`.`
 
 ### findMissing(locale, keysUsed)
 

--- a/src/extractFromCode.js
+++ b/src/extractFromCode.js
@@ -40,7 +40,12 @@ const commentRegExp = /i18n-extract (.+)/;
 const commentIgnoreRegExp = /i18n-extract-disable-line/;
 
 export default function extractFromCode(code, options = {}) {
-  const { marker = 'i18n', keyLoc = 0, useTypeScript = false } = options;
+  const { marker = 'i18n', keyLoc = 0, parser = 'flow' } = options;
+
+  const availableParsers = ['flow', 'typescript'];
+  if (!availableParsers.includes(parser)) {
+    throw new Error('Parser can be flow or typescript');
+  }
 
   const ast = parse(code, {
     sourceType: 'module',
@@ -61,7 +66,7 @@ export default function extractFromCode(code, options = {}) {
       'functionBind',
       'functionSent',
       'dynamicImport',
-    ].concat([useTypeScript ? 'typescript' : 'flow']),
+    ].concat([parser]),
   });
 
   const keys = [];

--- a/src/extractFromCode.js
+++ b/src/extractFromCode.js
@@ -44,7 +44,7 @@ export default function extractFromCode(code, options = {}) {
 
   const availableParsers = ['flow', 'typescript'];
   if (!availableParsers.includes(parser)) {
-    throw new Error('Parser can be flow or typescript');
+    throw new Error('Parser must be either flow or typescript');
   }
 
   const ast = parse(code, {

--- a/src/extractFromFiles.spec.js
+++ b/src/extractFromFiles.spec.js
@@ -212,7 +212,7 @@ describe('#extractFromFiles()', () => {
             parser: 'babel',
           },
         ),
-      'Parser can be flow or typescript',
+      'Parser must be either flow or typescript',
     );
   });
 });

--- a/src/extractFromFiles.spec.js
+++ b/src/extractFromFiles.spec.js
@@ -202,4 +202,17 @@ describe('#extractFromFiles()', () => {
       'should work when scanning typescript files',
     );
   });
+
+  it('should throw a error when pass wrong value to parser params', () => {
+    assert.throws(
+      () =>
+        extractFromFiles(
+          ['src/extractFromFilesFixture/*.tsx', 'src/extractFromFilesFixture/*.ts'],
+          {
+            parser: 'babel',
+          },
+        ),
+      'Parser can be flow or typescript',
+    );
+  });
 });

--- a/src/extractFromFiles.spec.js
+++ b/src/extractFromFiles.spec.js
@@ -172,7 +172,7 @@ describe('#extractFromFiles()', () => {
   it('should work when scanning typescript files', () => {
     const keys = extractFromFiles(
       ['src/extractFromFilesFixture/*.tsx', 'src/extractFromFilesFixture/*.ts'],
-      { useTypeScript: true },
+      { parser: 'typescript' },
     );
 
     assert.deepEqual(


### PR DESCRIPTION
In this PR, we change the option param 'useTypeScript' boolean by `parser` who is a enum and he can be `flow` or `typescript`