### PR TITLE
support custom babel config & transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ const keys = extractFromFiles([
 - `marker`: The name of the internationalized string marker function. Defaults to `i18n`.
 - `keyLoc`: An integer indicating the position of the key in the arguments. Defaults to `0`. Negative numbers, e.g., `-1`, indicate a position relative to the end of the argument list.
 - `parser`: Enum indicate the parser to use, can be `typescript` or `flow`. Defaults to `flow`.
+- `babelOptions`: A Babel [configuration object](https://babeljs.io/docs/en/options) to allow applying custom transformations or plugins before scanning for i18n keys. Defaults to a config with all babylon plugins enabled.
 
 ### findMissing(locale, keysUsed)
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@babel/core": "^7.0.0-beta.46",
     "@babel/register": "^7.0.0-beta.46",
     "@babel/traverse": "^7.0.0-beta.46",
-    "babylon": "^7.0.0-beta.46",
     "gettext-parser": "^1.3.1",
     "glob": "^7.1.2"
   },

--- a/src/extractFromFilesFixture/CustomTransform.js
+++ b/src/extractFromFilesFixture/CustomTransform.js
@@ -1,0 +1,9 @@
+/* eslint-disable */
+
+/**
+ * This would not normally be counted as an i18n key, but after applying a babel
+ * transform to rewrite it as `i18n('key1')`, it will!
+ */
+someCrazyThingThatRequiresABabelTransform({
+  foo: 'key1'
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,7 +1214,7 @@ babylon@7.0.0-beta.44:
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
   integrity sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==
 
-babylon@7.0.0-beta.46, babylon@^7.0.0-beta.46:
+babylon@7.0.0-beta.46:
   version "7.0.0-beta.46"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.46.tgz#b6ddaba81bbb130313932757ff9c195d527088b6"
   integrity sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg==


### PR DESCRIPTION
Fixes #54.

If custom code transformations are needed before scanning for i18n keys, they can now be specified as Babel plugins in the `babelOptions.plugins` option. This lets you avoid costly double parsing / code generation.