### PR TITLE
Handle nodes with null loc attribute (SourceLocation), add test

### DIFF
--- a/src/extractFromCode.js
+++ b/src/extractFromCode.js
@@ -128,9 +128,11 @@ export default function extractFromCode(code, options = {}) {
     CallExpression(path) {
       const { node } = path;
 
-      if (ignoredLines.includes(node.loc.end.line)) {
-        // Skip ignored lines
-        return;
+      if (node.loc) {
+        if (ignoredLines.includes(node.loc.end.line)) {
+          // Skip ignored lines
+          return;
+        }
       }
 
       const {

--- a/src/extractFromCode.spec.js
+++ b/src/extractFromCode.spec.js
@@ -832,6 +832,10 @@ describe('#extractFromCode()', () => {
       assert.deepEqual(
         [
           {
+            key: 'foo',
+            loc: undefined,
+          },
+          {
             key: 'this_is_a_custom_marker',
             loc: {
               end: {


### PR DESCRIPTION
Hi @oliviertassinari @sheerun

I added a test for https://github.com/oliviertassinari/i18n-extract/pull/62

Without the patch, it fails as expected:

```
  1) #extractFromCode()
       ast parsing
         can handle nodes with a null loc attribute (SourceLocation):
     TypeError: Cannot read property 'end' of undefined
      at end (src/extractFromCode.js:131:42)
      at NodePath._call (node_modules/@babel/traverse/lib/path/context.js:53:20)
      at NodePath.call (node_modules/@babel/traverse/lib/path/context.js:40:17)
      at NodePath.visit (node_modules/@babel/traverse/lib/path/context.js:88:12)
      at TraversalContext.visitQueue (node_modules/@babel/traverse/lib/context.js:112:16)
      at TraversalContext.visitMultiple (node_modules/@babel/traverse/lib/context.js:79:17)
      at TraversalContext.visit (node_modules/@babel/traverse/lib/context.js:138:19)
      at Function.traverse.node (node_modules/@babel/traverse/lib/index.js:80:17)
      at NodePath.visit (node_modules/@babel/traverse/lib/path/context.js:95:18)
      at TraversalContext.visitQueue (node_modules/@babel/traverse/lib/context.js:112:16)
      at TraversalContext.visitSingle (node_modules/@babel/traverse/lib/context.js:84:19)
      at TraversalContext.visit (node_modules/@babel/traverse/lib/context.js:140:19)
      at Function.traverse.node (node_modules/@babel/traverse/lib/index.js:80:17)
      at traverse (node_modules/@babel/traverse/lib/index.js:62:12)
      at extractFromCode (src/extractFromCode.js:127:3)
      at Context.<anonymous> (src/extractFromCode.spec.js:827:20)
```

I pulled in @sheerun's patch, which fixes the test.

Hope this looks good!