### PR TITLE
skip node with empty arguments

### DIFF
--- a/src/extractFromCode.js
+++ b/src/extractFromCode.js
@@ -135,6 +135,11 @@ export default function extractFromCode(code, options = {}) {
         }
       }
 
+      // Skip node with empty arguments
+      if (!node.arguments.length) {
+        return;
+      }
+
       const {
         callee: { name, type },
       } = node;


### PR DESCRIPTION
Some node have no arguments and it leads to an error in getKeys method. 